### PR TITLE
fixed wrong name in links

### DIFF
--- a/community/channels.rst
+++ b/community/channels.rst
@@ -4,4 +4,4 @@ Community channels
 ==================
 
 Currently, Scorpion does not have a community channel. You can open a discussion on the 
-`GitHub repository <https://github.com/ScorpionAntimalware/scorpion-antimalware/discussions>`_.
+`GitHub repository <https://github.com/scorpionantimalware/scorpion-antimalware/discussions>`_.

--- a/conf.py
+++ b/conf.py
@@ -7,8 +7,8 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "scorpion-antimalware"
-copyright = "2023, ScorpionAntimalware"
-author = "ScorpionAntimalware"
+copyright = "2023, Scorpion Anti-malware"
+author = "Scorpion Anti-malware"
 release = "0.1"
 
 # -- General configuration ---------------------------------------------------

--- a/contributing/development/compiling/getting_source.rst
+++ b/contributing/development/compiling/getting_source.rst
@@ -12,7 +12,7 @@ Downloading the Scorpion source code
 .. and compiling Scorpion, you need to actually download the Scorpion source code.
 
 The source code is available on 
-`ScorpionAntimalware/scorpion-antimalware <https://github.com/ScorpionAntimalware/scorpion-antimalware>`_
+`scorpionantimalware/scorpion-antimalware <https://github.com/scorpionantimalware/scorpion-antimalware>`_
 and while you can manually download it via the website, in general you want to
 do it via the ``git`` version control system.
 
@@ -23,14 +23,14 @@ In general, you need to install ``git`` and/or one of the various GUI clients.
 
 Afterwards, to get the latest development version of the Scorpion source code
 (the unstable ``master`` branch), you can use 
-``git clone --recurse-submodules --depth 1 --shallow-submodules https://github.com/ScorpionAntimalware/scorpion-antimalware.git``.
+``git clone --recurse-submodules --depth 1 --shallow-submodules https://github.com/scorpionantimalware/scorpion-antimalware.git``.
 
 If you are using the ``git`` command line client, this is done by entering
 the following in a terminal:
 
 ::
 
-    git clone https://github.com/ScorpionAntimalware/scorpion-antimalware.git
+    git clone https://github.com/scorpionantimalware/scorpion-antimalware.git
     # You can add the --depth 1 argument to omit the commit history.
     # Faster, but not all Git operations (like blame) will work.
 
@@ -44,8 +44,8 @@ Downloading the Console source code
 -----------------------------------
 
 The source code is available on 
-`ScorpionAntimalware/sam-console <https://github.com/ScorpionAntimalware/sam-console>`_
+`scorpionantimalware/sam-console <https://github.com/scorpionantimalware/sam-console>`_
 and while you can manually download it via the website, in general you want to
 do it via the ``git`` version control system using the following command:
-``git clone --recurse-submodules --depth 1 --shallow-submodules https://github.com/ScorpionAntimalware/sam-console.git``.
+``git clone --recurse-submodules --depth 1 --shallow-submodules https://github.com/scorpionantimalware/sam-console.git``.
 

--- a/contributing/documentation/building_the_documentation.rst
+++ b/contributing/documentation/building_the_documentation.rst
@@ -22,7 +22,7 @@ Before you get started, make sure that you have:
 
     .. code:: sh
 
-        git clone https://github.com/ScorpionAntimalware/sam-docs.git
+        git clone https://github.com/scorpionantimalware/sam-docs.git
 
 .. note:: You can add the --depth 1 argument to omit the commit history.
           Faster, but not all Git operations (like blame) will work.

--- a/contributing/documentation/contributing_to_the_documentation.rst
+++ b/contributing/documentation/contributing_to_the_documentation.rst
@@ -4,6 +4,6 @@ Contributing to the documentation
 =================================
 
 The documentation is written in reStructuredText and built using Sphinx. The
-source files are located at `ScorpionAntimalware/sam-console <https://github.com/ScorpionAntimalware/sam-console>`_.
+source files are located at `scorpionantimalware/sam-console <https://github.com/scorpionantimalware/sam-console>`_.
 
 We welcome contributions to the documentation by opening a pull request or reporting an issue.

--- a/models/index.rst
+++ b/models/index.rst
@@ -7,7 +7,7 @@ Our pipeline contains multiple models.
 
 .. You can find more information about our Signature-based process here ` <>`_.
 
-You can find our open-source models here `sam-models <https://github.com/ScorpionAntimalware/sam-models>`_.
+You can find our open-source models here `sam-models <https://github.com/scorpionantimalware/sam-models>`_.
 
 Also, our trained models are available inside this Google Drive folder 
 `SAM Models <https://drive.google.com/drive/folders/1frJ8Pll8AdRHpTnSHSCPZEVvOz_FHSRT?usp=drive_link>`_.


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

DON'T target the `master-published` or `master-ready` branches as the code inside it is automatically generated.
-->
